### PR TITLE
Update a development link to point to main

### DIFF
--- a/src/pages/getting-started.js
+++ b/src/pages/getting-started.js
@@ -17,7 +17,7 @@ const gettingStartedLinks = [
   },
   {
     name: 'Quick Start Guide',
-    href: 'https://warewulf.org/docs/development/quickstart/el8.html',
+    href: 'https://warewulf.org/docs/main/quickstart/el.html',
     description:
       'Check out the quick start documentation to get Warewulf installed and set up in a hurry.',
     icon: NewspaperIcon,


### PR DESCRIPTION
We were notified in Slack recently that a link from the website leads to the old "development" documentation.

> quick start link from https://warewulf.org/getting-started/ goes to development

https://warewulf.slack.com/archives/C06750GH799/p1711579092125869

This PR updates the link to point to the main version of the docs.

But I don't understand why the redirect at https://github.com/warewulf/warewulf.org/blob/main/gatsby-node.js aren't working, either.